### PR TITLE
Develop

### DIFF
--- a/components/ReportPolluted.jsx
+++ b/components/ReportPolluted.jsx
@@ -1,431 +1,426 @@
 "use client";
-import {useState, useCallback} from "react";
-import {useForm} from "react-hook-form";
-import {zodResolver} from "@hookform/resolvers/zod";
-import {reportSchema} from "@/lib/formschema";
-import {Button} from "@/components/ui/button";
-import {Input} from "@/components/ui/input";
-import {Textarea} from "@/components/ui/textarea";
+import { useState, useCallback, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { reportSchema } from "@/lib/formschema";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import {
-    Card,
-    CardHeader,
-    CardContent,
-    CardTitle,
-    CardDescription
+  Card,
+  CardHeader,
+  CardContent,
+  CardTitle,
+  CardDescription,
 } from "@/components/ui/card";
 import {
-    Form,
-    FormControl,
-    FormField,
-    FormItem,
-    FormLabel,
-    FormMessage
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
 } from "@/components/ui/form";
 import {
-    AlertDialog,
-    AlertDialogAction,
-    AlertDialogCancel,
-    AlertDialogContent,
-    AlertDialogDescription,
-    AlertDialogFooter,
-    AlertDialogHeader,
-    AlertDialogTitle,
-    AlertDialogTrigger
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import {LoadingModal} from "@/components/ui/LoadingModal";
+import { LoadingModal } from "@/components/ui/LoadingModal";
 import ThanksComponent from "@/components/ui/thanks";
-import {useTranslation} from "react-i18next";
-import {Popover, PopoverContent, PopoverTrigger} from "@/components/ui/popover";
-import {Calendar} from "@/components/ui/calendar";
-import {CalendarIcon, Trash2} from "lucide-react";
-import {format} from "date-fns";
-import {cn} from "@/lib/utils";
+import { useTranslation } from "react-i18next";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Calendar } from "@/components/ui/calendar";
+import { CalendarIcon, Trash2 } from "lucide-react";
+import { format } from "date-fns";
+import { cn } from "@/lib/utils";
+import {SkeletonReportPolluted} from "@/components/skeleton/SkeletonReport";
 
 export function ReportPolluted() {
-    const [isDialogOpen, setIsDialogOpen] = useState(false);
-    const [isLoading, setIsLoading] = useState(false);
-    const [isThanksOpen, setIsThanksOpen] = useState(false);
-    const [formData, setFormData] = useState(null);
-    const [imagePreviews, setImagePreviews] = useState([]);
-    const {t} = useTranslation();
-    const form = useForm({
-        resolver: zodResolver(reportSchema),
-        defaultValues: {
-            fullName: "",
-            phoneNumber: "",
-            email: "",
-            reportDestinationAddress: "",
-            reportDestinationName: "",
-            reportActualDate: "",
-            description: "",
-            images: [],
-        },
-        mode: "onChange",
-    });
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isThanksOpen, setIsThanksOpen] = useState(false);
+  const [formData, setFormData] = useState(null);
+  const [imagePreviews, setImagePreviews] = useState([]);
+  const { t } = useTranslation();
+  const form = useForm({
+    resolver: zodResolver(reportSchema),
+    defaultValues: {
+      fullName: "",
+      phoneNumber: "",
+      email: "",
+      reportDestinationAddress: "",
+      reportDestinationName: "",
+      reportActualDate: "",
+      description: "",
+      images: [],
+    },
+    mode: "onChange",
+  });
 
-    const {handleSubmit, formState: {errors, isValid}} = form;
+  const { handleSubmit, formState: { errors, isValid } } = form;
 
+  useEffect(() => {
+    // Simulate data fetching
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 2000); // Adjust the timeout as needed
+  }, []);
 
-    const onSubmit = useCallback(async (data) => {
-        setIsLoading(true);
+  const onSubmit = useCallback(async (data) => {
+    setIsLoading(true);
 
-        try {
-            // Step 1: Upload images to Strapi
-            const imageUploadPromises = data.images.map(async (image) => {
-                const formData = new FormData();
-                formData.append('files', image);
+    try {
+      // Step 1: Upload images to Strapi
+      const imageUploadPromises = data.images.map(async (image) => {
+        const formData = new FormData();
+        formData.append('files', image);
 
-                const uploadResponse = await fetch(`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/upload/`, {
-                    method: 'POST',
-                    headers: {
-                        'Authorization': `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
-                    },
-                    body: formData,
-                });
+        const uploadResponse = await fetch(`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/upload/`, {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
+          },
+          body: formData,
+        });
 
-                if (!uploadResponse.ok) {
-                    throw new Error('Failed to upload image');
-                }
-
-                const uploadData = await uploadResponse.json();
-                // Return the ID of the uploaded image, not the URL or name
-                return uploadData[0].id;
-            });
-
-            // Wait for all images to be uploaded
-            const uploadedImageIds = await Promise.all(imageUploadPromises);
-
-            // Step 2: Submit the report data with uploaded image IDs
-            const formattedData = {
-                data: {
-                    full_name: data.fullName,
-                    email: data.email,
-                    phone_number: data.phoneNumber,
-                    date: data.reportActualDate,
-                    report_destination_address: data.reportDestinationAddress,
-                    report_destination_name: data.reportDestinationName,
-                    descriptions: data.description,
-                    // Use the image IDs instead of URL and name
-                    images: uploadedImageIds.map(id => ({id}))
-                }
-            };
-
-            const response = await fetch(`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/reports?populate=*`, {
-                method: 'POST',
-                headers: {
-                    'Authorization': `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(formattedData),
-            });
-
-            if (response.ok) {
-                setIsThanksOpen(true);
-            } else {
-                const errorData = await response.json();
-                console.error('Error Response Data:', errorData);
-                alert('Failed to submit report. Check console for details.');
-            }
-        } catch (error) {
-            console.error('Error in onSubmit function:', error);
-            alert('An error occurred while submitting the report.');
-        } finally {
-            setIsLoading(false);
+        if (!uploadResponse.ok) {
+          throw new Error('Failed to upload image');
         }
-    }, []);
 
+        const uploadData = await uploadResponse.json();
+        // Return the ID of the uploaded image, not the URL or name
+        return uploadData[0].id;
+      });
 
-    const handleConfirm = useCallback(async () => {
-        setIsDialogOpen(false);
-        if (formData) await onSubmit(formData);
-    }, [formData, onSubmit]);
+      // Wait for all images to be uploaded
+      const uploadedImageIds = await Promise.all(imageUploadPromises);
 
-    const handleSaveData = useCallback((data) => {
-        setFormData(data);
-        setIsDialogOpen(true);
-    }, []);
+      // Step 2: Submit the report data with uploaded image IDs
+      const formattedData = {
+        data: {
+          full_name: data.fullName,
+          email: data.email,
+          phone_number: data.phoneNumber,
+          date: data.reportActualDate,
+          report_destination_address: data.reportDestinationAddress,
+          report_destination_name: data.reportDestinationName,
+          descriptions: data.description,
+          // Use the image IDs instead of URL and name
+          images: uploadedImageIds.map(id => ({ id }))
+        }
+      };
 
-    const handleCloseThanks = useCallback(() => {
-        setIsThanksOpen(false);
-        window.location.reload();
-    }, []);
+      const response = await fetch(`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/reports?populate=*`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(formattedData),
+      });
 
+      if (response.ok) {
+        setIsThanksOpen(true);
+      } else {
+        const errorData = await response.json();
+        console.error('Error Response Data:', errorData);
+        alert('Failed to submit report. Check console for details.');
+      }
+    } catch (error) {
+      console.error('Error in onSubmit function:', error);
+      alert('An error occurred while submitting the report.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
 
-    const handleImageChange = useCallback((e) => {
-        const files = Array.from(e.target.files);
-        const newImages = files.map((file) => ({
-            id: URL.createObjectURL(file),
-            file,
-        }));
+  const handleConfirm = useCallback(async () => {
+    setIsDialogOpen(false);
+    if (formData) await onSubmit(formData);
+  }, [formData, onSubmit]);
 
-        // Add new images to both previews and form values
-        setImagePreviews((prev) => [...prev, ...newImages]);
-        form.setValue(
-            "images",
-            [...form.getValues("images"), ...files],
-            {shouldValidate: true}
-        );
+  const handleSaveData = useCallback((data) => {
+    setFormData(data);
+    setIsDialogOpen(true);
+  }, []);
 
-        console.log('form.getValues("images"):', form.getValues("images"));
-    }, [form]);
+  const handleCloseThanks = useCallback(() => {
+    setIsThanksOpen(false);
+    window.location.reload();
+  }, []);
 
-    const handleRemoveImage = useCallback((id) => {
-        // Find the image to be removed based on the object URL
-        const imageToRemove = imagePreviews.find((image) => image.id === id);
-        if (!imageToRemove) return;
+  const handleImageChange = useCallback((e) => {
+    const files = Array.from(e.target.files);
+    const newImages = files.map((file) => ({
+      id: URL.createObjectURL(file),
+      file,
+    }));
 
-        // Revoke the object URL to avoid memory leaks
-        URL.revokeObjectURL(id);
-
-        // Update image previews
-        setImagePreviews((prev) => prev.filter((image) => image.id !== id));
-
-        // Remove the file from the form's "images" field
-        const updatedImages = form
-            .getValues("images")
-            .filter((imageFile) => imageFile !== imageToRemove.file);
-        form.setValue("images", updatedImages, {shouldValidate: true});
-
-        console.log('Updated images:', updatedImages);
-    }, [form, imagePreviews]);
-
-
-    return (
-        <div id="report-polluted"
-             className="flex flex-col items-center justify-start max-w-7xl mx-auto px-4 overflow-hidden">
-            <div className="flex flex-col md:gap-32 items-center md:flex-row w-full">
-                <div className="md:w-1/2 p-4">
-                    <h2 className="text-3xl font-bold mb-4">{t("report_polluted")}</h2>
-                    <p className="text-gray-700 md:text-lg mb-4">{t("help_us")}</p>
-                </div>
-                <Card className="shadow-lg w-full my-20 max-w-xl p-4">
-                    <CardHeader>
-                        <CardTitle>{t("report_polluted_area")}</CardTitle>
-                        <CardDescription>{t("help_us_keep_the_environment_clean")}</CardDescription>
-                    </CardHeader>
-
-                    <CardContent>
-                        <Form {...form}>
-                            <form onSubmit={handleSubmit(onSubmit)}
-                                  className="space-y-4">
-                                <div
-                                    className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                    <FormField
-                                        control={form.control}
-                                        name="fullName"
-                                        render={({field}) => (
-                                            <FormItem>
-                                                <FormLabel>{t("full_name")}<span
-                                                    className="text-red-500">*</span></FormLabel>
-                                                <FormControl>
-                                                    <Input
-                                                        placeholder={t("enter_full_name")} {...field}
-                                                        value={field.value || ""}
-                                                        className="w-full bg-gray-100 p-2 border border-gray-300 rounded"/>
-                                                </FormControl>
-                                                <FormMessage/>
-                                            </FormItem>
-                                        )}
-                                    />
-
-                                    <FormField
-                                        control={form.control}
-                                        name="phoneNumber"
-                                        render={({field}) => (
-                                            <FormItem>
-                                                <FormLabel>{t("phone_number")}<span
-                                                    className="text-red-500">*</span></FormLabel>
-                                                <FormControl>
-                                                    <Input type="tel"
-                                                           placeholder={t("enter_phone_number")} {...field}
-                                                           value={field.value || ""}
-                                                           className="w-full bg-gray-100 p-2 border border-gray-300 rounded"/>
-                                                </FormControl>
-                                                <FormMessage/>
-                                            </FormItem>
-                                        )}
-                                    />
-
-                                    <FormField
-                                        control={form.control}
-                                        name="email"
-                                        render={({field}) => (
-                                            <FormItem>
-                                                <FormLabel>{t("email")}<span
-                                                    className="text-red-500">*</span></FormLabel>
-                                                <FormControl>
-                                                    <Input type="email"
-                                                           placeholder={t("enter_email")} {...field}
-                                                           value={field.value || ""}
-                                                           className="w-full bg-gray-100 p-2 border border-gray-300 rounded"/>
-                                                </FormControl>
-                                                <FormMessage/>
-                                            </FormItem>
-                                        )}
-                                    />
-
-                                    <FormField
-                                        control={form.control}
-                                        name="reportDestinationAddress"
-                                        render={({field}) => (
-                                            <FormItem>
-                                                <FormLabel>{t("report_destination_address")}<span
-                                                    className="text-red-500">*</span></FormLabel>
-                                                <FormControl>
-                                                    <Input
-                                                        placeholder={t("enter_report_destination_address")} {...field}
-                                                        value={field.value || ""}
-                                                        className="w-full bg-gray-100 p-2 border border-gray-300 rounded"/>
-                                                </FormControl>
-                                                <FormMessage/>
-                                            </FormItem>
-                                        )}
-                                    />
-
-                                    <FormField
-                                        control={form.control}
-                                        name="reportDestinationName"
-                                        render={({field}) => (
-                                            <FormItem>
-                                                <FormLabel>{t("report_destination_name")}<span
-                                                    className="text-red-500">*</span></FormLabel>
-                                                <FormControl>
-                                                    <Input
-                                                        placeholder={t("enter_report_destination_name")} {...field}
-                                                        value={field.value || ""}
-                                                        className="w-full bg-gray-100 p-2 border border-gray-300 rounded"/>
-                                                </FormControl>
-                                                <FormMessage/>
-                                            </FormItem>
-                                        )}
-                                    />
-
-                                    <FormField
-                                        control={form.control}
-                                        name="reportActualDate"
-                                        render={({field}) => (
-                                            <FormItem>
-                                                <FormLabel>{t("report_actual_date")}<span
-                                                    className="text-red-500">*</span></FormLabel>
-                                                <FormControl>
-                                                    <Popover>
-                                                        <PopoverTrigger asChild>
-                                                            <Button
-                                                                variant={"outline"}
-                                                                className={cn(
-                                                                    "w-full justify-start text-left font-normal",
-                                                                    !field.value && "text-muted-foreground"
-                                                                )}
-                                                            >
-                                                                <CalendarIcon/>
-                                                                {field.value ? format(new Date(field.value), "PPP") :
-                                                                    <span>{t("pick_a_date")}</span>}
-                                                            </Button>
-                                                        </PopoverTrigger>
-                                                        <PopoverContent
-                                                            className="w-auto p-0"
-                                                            align="start">
-                                                            <Calendar
-                                                                mode="single"
-                                                                selected={field.value ? new Date(field.value) : undefined}
-                                                                onSelect={(date) => field.onChange(date ? date.toISOString() : "")}
-                                                                initialFocus
-                                                            />
-                                                        </PopoverContent>
-                                                    </Popover>
-                                                </FormControl>
-                                                <FormMessage/>
-                                            </FormItem>
-                                        )}
-                                    />
-
-                                    <FormField
-                                        control={form.control}
-                                        name="description"
-                                        render={({field}) => (
-                                            <FormItem className="md:col-span-2">
-                                                <FormLabel>{t("description")}<span
-                                                    className="text-red-500">*</span></FormLabel>
-                                                <FormControl>
-                                                    <Textarea
-                                                        placeholder={t("enter_description")} {...field}
-                                                        value={field.value || ""}
-                                                        className="w-full bg-gray-100 p-2 border border-gray-300 rounded"/>
-                                                </FormControl>
-                                                <FormMessage/>
-                                            </FormItem>
-                                        )}
-                                    />
-
-                                    <FormField
-                                        control={form.control}
-                                        name="images"
-                                        render={({field}) => (
-                                            <FormItem className="md:col-span-2">
-                                                <FormLabel>{t("upload_image")}<span
-                                                    className="text-red-500">*</span></FormLabel>
-                                                <FormControl>
-                                                    <Input type="file"
-                                                           accept="image/*"
-                                                           multiple
-                                                           onChange={handleImageChange}
-                                                           className="w-full bg-gray-100 p-2 border border-gray-300 rounded"/>
-                                                </FormControl>
-                                                <FormMessage/>
-                                                <div
-                                                    className="mt-4 grid grid-cols-2 gap-4">
-                                                    {imagePreviews.map((image, index) => (
-                                                        <div key={index}
-                                                             className="relative">
-                                                            <img src={image.id}
-                                                                 alt={`Preview ${index}`}
-                                                                 className="w-full h-auto rounded"/>
-                                                            <button
-                                                                type="button"
-                                                                onClick={() => handleRemoveImage(image.id)}
-                                                                className="absolute top-2 right-2 bg-white rounded-full p-1 shadow">
-                                                                <Trash2
-                                                                    className="w-4 h-4 text-red-600"/>
-                                                            </button>
-                                                        </div>
-                                                    ))}
-                                                </div>
-                                            </FormItem>
-                                        )}
-                                    />
-                                </div>
-
-                                <AlertDialog open={isDialogOpen}
-                                             onOpenChange={setIsDialogOpen}>
-                                    <AlertDialogTrigger asChild>
-                                        <Button type="button"
-                                                className={`w-full ${!isValid ? 'cursor-not-allowed' : 'cursor-pointer'}`}
-                                                onClick={handleSubmit(handleSaveData)}>
-                                            {t("submit_report")}
-                                        </Button>
-                                    </AlertDialogTrigger>
-                                    <AlertDialogContent>
-                                        <AlertDialogHeader>
-                                            <AlertDialogTitle>{t("confirm_submission")}</AlertDialogTitle>
-                                            <AlertDialogDescription>{t("are_you_sure_submit")}</AlertDialogDescription>
-                                        </AlertDialogHeader>
-                                        <AlertDialogFooter>
-                                            <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
-                                            <AlertDialogAction
-                                                onClick={handleConfirm}>{t("confirm")}</AlertDialogAction>
-                                        </AlertDialogFooter>
-                                    </AlertDialogContent>
-                                </AlertDialog>
-
-                                <LoadingModal isOpen={isLoading}/>
-                            </form>
-                        </Form>
-                    </CardContent>
-                </Card>
-            </div>
-
-            <ThanksComponent isOpen={isThanksOpen}
-                             onClose={handleCloseThanks}/>
-        </div>
+    // Add new images to both previews and form values
+    setImagePreviews((prev) => [...prev, ...newImages]);
+    form.setValue(
+      "images",
+      [...form.getValues("images"), ...files],
+      { shouldValidate: true }
     );
+
+    console.log('form.getValues("images"):', form.getValues("images"));
+  }, [form]);
+
+  const handleRemoveImage = useCallback((id) => {
+    // Find the image to be removed based on the object URL
+    const imageToRemove = imagePreviews.find((image) => image.id === id);
+    if (!imageToRemove) return;
+
+    // Revoke the object URL to avoid memory leaks
+    URL.revokeObjectURL(id);
+
+    // Update image previews
+    setImagePreviews((prev) => prev.filter((image) => image.id !== id));
+
+    // Remove the file from the form's "images" field
+    const updatedImages = form
+      .getValues("images")
+      .filter((imageFile) => imageFile !== imageToRemove.file);
+    form.setValue("images", updatedImages, { shouldValidate: true });
+
+    console.log('Updated images:', updatedImages);
+  }, [form, imagePreviews]);
+
+  if (isLoading) {
+    return <SkeletonReportPolluted />;
+  }
+
+  return (
+    <div id="report-polluted" className="flex flex-col items-center justify-start max-w-7xl mx-auto px-4 overflow-hidden">
+      <div className="flex flex-col md:gap-32 items-center md:flex-row w-full">
+        <div className="md:w-1/2 p-4">
+          <h2 className="text-3xl font-bold mb-4">{t("report_polluted")}</h2>
+          <p className="text-gray-700 md:text-lg mb-4">{t("help_us")}</p>
+        </div>
+        <Card className="shadow-lg w-full my-20 max-w-xl p-4">
+          <CardHeader>
+            <CardTitle>{t("report_polluted_area")}</CardTitle>
+            <CardDescription>{t("help_us_keep_the_environment_clean")}</CardDescription>
+          </CardHeader>
+
+          <CardContent>
+            <Form {...form}>
+              <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <FormField
+                    control={form.control}
+                    name="fullName"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("full_name")}<span className="text-red-500">*</span></FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder={t("enter_full_name")} {...field}
+                            value={field.value || ""}
+                            className="w-full bg-gray-100 p-2 border border-gray-300 rounded" />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="phoneNumber"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("phone_number")}<span className="text-red-500">*</span></FormLabel>
+                        <FormControl>
+                          <Input type="tel"
+                            placeholder={t("enter_phone_number")} {...field}
+                            value={field.value || ""}
+                            className="w-full bg-gray-100 p-2 border border-gray-300 rounded" />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="email"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("email")}<span className="text-red-500">*</span></FormLabel>
+                        <FormControl>
+                          <Input type="email"
+                            placeholder={t("enter_email")} {...field}
+                            value={field.value || ""}
+                            className="w-full bg-gray-100 p-2 border border-gray-300 rounded" />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="reportDestinationAddress"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("report_destination_address")}<span className="text-red-500">*</span></FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder={t("enter_report_destination_address")} {...field}
+                            value={field.value || ""}
+                            className="w-full bg-gray-100 p-2 border border-gray-300 rounded" />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="reportDestinationName"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("report_destination_name")}<span className="text-red-500">*</span></FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder={t("enter_report_destination_name")} {...field}
+                            value={field.value || ""}
+                            className="w-full bg-gray-100 p-2 border border-gray-300 rounded" />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="reportActualDate"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("report_actual_date")}<span className="text-red-500">*</span></FormLabel>
+                        <FormControl>
+                          <Popover>
+                            <PopoverTrigger asChild>
+                              <Button
+                                variant={"outline"}
+                                className={cn(
+                                  "w-full justify-start text-left font-normal",
+                                  !field.value && "text-muted-foreground"
+                                )}
+                              >
+                                <CalendarIcon />
+                                {field.value ? format(new Date(field.value), "PPP") :
+                                  <span>{t("pick_a_date")}</span>}
+                              </Button>
+                            </PopoverTrigger>
+                            <PopoverContent
+                              className="w-auto p-0"
+                              align="start">
+                              <Calendar
+                                mode="single"
+                                selected={field.value ? new Date(field.value) : undefined}
+                                onSelect={(date) => field.onChange(date ? date.toISOString() : "")}
+                                initialFocus
+                              />
+                            </PopoverContent>
+                          </Popover>
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="description"
+                    render={({ field }) => (
+                      <FormItem className="md:col-span-2">
+                        <FormLabel>{t("description")}<span className="text-red-500">*</span></FormLabel>
+                        <FormControl>
+                          <Textarea
+                            placeholder={t("enter_description")} {...field}
+                            value={field.value || ""}
+                            className="w-full bg-gray-100 p-2 border border-gray-300 rounded" />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="images"
+                    render={({ field }) => (
+                      <FormItem className="md:col-span-2">
+                        <FormLabel>{t("upload_image")}<span className="text-red-500">*</span></FormLabel>
+                        <FormControl>
+                          <Input type="file"
+                            accept="image/*"
+                            multiple
+                            onChange={handleImageChange}
+                            className="w-full bg-gray-100 p-2 border border-gray-300 rounded" />
+                        </FormControl>
+                        <FormMessage />
+                        <div className="mt-4 grid grid-cols-2 gap-4">
+                          {imagePreviews.map((image, index) => (
+                            <div key={index} className="relative">
+                              <img src={image.id}
+                                alt={`Preview ${index}`}
+                                className="w-full h-auto rounded" />
+                              <button
+                                type="button"
+                                onClick={() => handleRemoveImage(image.id)}
+                                className="absolute top-2 right-2 bg-white rounded-full p-1 shadow">
+                                <Trash2
+                                  className="w-4 h-4 text-red-600" />
+                              </button>
+                            </div>
+                          ))}
+                        </div>
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <AlertDialog open={isDialogOpen}
+                  onOpenChange={setIsDialogOpen}>
+                  <AlertDialogTrigger asChild>
+                    <Button type="button"
+                      className={`w-full ${!isValid ? 'cursor-not-allowed' : 'cursor-pointer'}`}
+                      onClick={handleSubmit(handleSaveData)}>
+                      {t("submit_report")}
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>{t("confirm_submission")}</AlertDialogTitle>
+                      <AlertDialogDescription>{t("are_you_sure_submit")}</AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={handleConfirm}>{t("confirm")}</AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+
+                <LoadingModal isOpen={isLoading} />
+              </form>
+            </Form>
+          </CardContent>
+        </Card>
+      </div>
+
+      <ThanksComponent isOpen={isThanksOpen}
+        onClose={handleCloseThanks} />
+    </div>
+  );
 }

--- a/components/ToggleLanguage.jsx
+++ b/components/ToggleLanguage.jsx
@@ -20,7 +20,7 @@ export default function ToggleLanguage() {
 
   // Set current locale based on URL path on initial load
   useEffect(() => {
-    const pathLocale = currentPathname.startsWith("/id") ? "id" : "en";
+    const pathLocale = currentPathname.startsWith("/en") ? "en" : "id";
     setCurrentLocale(pathLocale);
   }, [currentPathname]);
 
@@ -34,7 +34,7 @@ export default function ToggleLanguage() {
     // Update URL path based on the selected locale
     const newPath =
         newLocale === defaultLocale && !i18nConfig.prefixDefault
-            ? currentPathname.replace(/^\/(id)/, "") || "/" // remove locale prefix for default
+            ? currentPathname.replace(/^\/(id|en)/, "") || "/" // remove locale prefix for default
             : `/${newLocale}${currentPathname.replace(/^\/(id|en)/, "")}`;
 
     router.push(newPath);
@@ -42,7 +42,7 @@ export default function ToggleLanguage() {
   };
 
   return (
-    <Select  onValueChange={handleChange} value={currentLocale}>
+    <Select onValueChange={handleChange} value={currentLocale}>
       <SelectTrigger className="">
         <SelectValue placeholder="Select Language" />
       </SelectTrigger>
@@ -53,7 +53,7 @@ export default function ToggleLanguage() {
         </SelectItem>
         <SelectItem value="id">
           <ID title="Indonesia" className="inline-block mr-2 w-5 h-5" />
-          <span className="hidden sm:inline ">Indonesian</span>
+          <span className="hidden sm:inline">Indonesian</span>
         </SelectItem>
       </SelectContent>
     </Select>

--- a/components/skeleton/SkeletonReport.jsx
+++ b/components/skeleton/SkeletonReport.jsx
@@ -1,0 +1,33 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function SkeletonReportPolluted() {
+  return (
+    <div id="report-polluted" className="flex flex-col items-center justify-start max-w-7xl mx-auto px-4 overflow-hidden">
+      <div className="flex flex-col md:gap-32 items-center md:flex-row w-full">
+        <div className="md:w-1/2 p-4">
+          <Skeleton className="h-8 w-3/4 mb-4" />
+          <Skeleton className="h-6 w-1/2 mb-4" />
+        </div>
+        <div className="shadow-lg w-full my-20 max-w-xl p-4">
+          <div className="space-y-4">
+            <Skeleton className="h-8 w-1/2 mb-4" />
+            <Skeleton className="h-6 w-3/4 mb-4" />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <Skeleton className="h-10 w-full mb-4" />
+              <Skeleton className="h-10 w-full mb-4" />
+              <Skeleton className="h-10 w-full mb-4" />
+              <Skeleton className="h-10 w-full mb-4" />
+              <Skeleton className="h-10 w-full mb-4" />
+              <Skeleton className="h-10 w-full mb-4" />
+              <Skeleton className="h-10 w-full mb-4" />
+              <Skeleton className="h-10 w-full mb-4" />
+            </div>
+            <Skeleton className="h-20 w-full mb-4" />
+            <Skeleton className="h-10 w-full mb-4" />
+            <Skeleton className="h-12 w-full" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/i18nConfig.js
+++ b/i18nConfig.js
@@ -1,6 +1,6 @@
 const i18nConfig = {
   locales: ["en", "id"],
-  defaultLocale: "en",
+  defaultLocale: "id",
   prefixDefault: false,
   serverSetCookie:"never",
 };


### PR DESCRIPTION
This pull request includes multiple changes to the `components/ReportPolluted.jsx` file, as well as modifications to the `ToggleLanguage` component and the addition of a new skeleton component. The most important changes include adding a loading state with a skeleton component, updating locale handling, and cleaning up imports and formatting.

Loading state and skeleton component:

* Added `SkeletonReportPolluted` component to display a loading skeleton while data is being fetched (`components/skeleton/SkeletonReport.jsx`).
* Updated `ReportPolluted` component to use `SkeletonReportPolluted` during the loading state (`components/ReportPolluted.jsx`). [[1]](diffhunk://#diff-7be20c000d27fc4896a51f003963505de15bb2f91c891ed41899da50b2cdb71fR43-R47) [[2]](diffhunk://#diff-7be20c000d27fc4896a51f003963505de15bb2f91c891ed41899da50b2cdb71fR69-R74) [[3]](diffhunk://#diff-7be20c000d27fc4896a51f003963505de15bb2f91c891ed41899da50b2cdb71fR197-R202)

Locale handling:

* Changed the default locale to "id" in `i18nConfig.js` (`i18nConfig.js`).
* Updated `ToggleLanguage` component to correctly handle locale prefixes in URLs (`components/ToggleLanguage.jsx`). [[1]](diffhunk://#diff-53b509cf763665aeaf95d5587a208a292cd381ca7cb2332e63347386664c18e6L23-R23) [[2]](diffhunk://#diff-53b509cf763665aeaf95d5587a208a292cd381ca7cb2332e63347386664c18e6L37-R37)

Import and formatting cleanup:

* Cleaned up import statements and added missing dependencies in `ReportPolluted` component (`components/ReportPolluted.jsx`). [[1]](diffhunk://#diff-7be20c000d27fc4896a51f003963505de15bb2f91c891ed41899da50b2cdb71fL2-R2) [[2]](diffhunk://#diff-7be20c000d27fc4896a51f003963505de15bb2f91c891ed41899da50b2cdb71fL14-R22) [[3]](diffhunk://#diff-7be20c000d27fc4896a51f003963505de15bb2f91c891ed41899da50b2cdb71fL33-R33)
* Formatted JSX elements for better readability in `ReportPolluted` component (`components/ReportPolluted.jsx`). [[1]](diffhunk://#diff-7be20c000d27fc4896a51f003963505de15bb2f91c891ed41899da50b2cdb71fL209-R223) [[2]](diffhunk://#diff-7be20c000d27fc4896a51f003963505de15bb2f91c891ed41899da50b2cdb71fL236-R240) [[3]](diffhunk://#diff-7be20c000d27fc4896a51f003963505de15bb2f91c891ed41899da50b2cdb71fL254-R257) [[4]](diffhunk://#diff-7be20c000d27fc4896a51f003963505de15bb2f91c891ed41899da50b2cdb71fL272-R274) [[5]](diffhunk://#diff-7be20c000d27fc4896a51f003963505de15bb2f91c891ed41899da50b2cdb71fL290-R291) [[6]](diffhunk://#diff-7be20c000d27fc4896a51f003963505de15bb2f91c891ed41899da50b2cdb71fL308-R308) [[7]](diffhunk://#diff-7be20c000d27fc4896a51f003963505de15bb2f91c891ed41899da50b2cdb71fL347-R346) [[8]](diffhunk://#diff-7be20c000d27fc4896a51f003963505de15bb2f91c891ed41899da50b2cdb71fL365-R363) [[9]](diffhunk://#diff-7be20c000d27fc4896a51f003963505de15bb2f91c891ed41899da50b2cdb71fL375-R374)